### PR TITLE
update to Confluence 6.13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM blacklabelops/java:server-jre.8.162
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
-ARG CONFLUENCE_VERSION=6.13.1
+ARG CONFLUENCE_VERSION=6.13.3
 # permissions
 ARG CONTAINER_UID=1000
 ARG CONTAINER_GID=1000

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Product |Version | Tags  | Dockerfile |
 |---------|--------|-------|------------|
-| Confluence | 6.13.1 | 6.13.1, latest | [Dockerfile](https://github.com/blacklabelops/confluence/blob/master/Dockerfile) |
+| Confluence | 6.13.3 | 6.13.3, latest | [Dockerfile](https://github.com/blacklabelops/confluence/blob/master/Dockerfile) |
 
 # Related Images
 

--- a/buildscripts/release.sh
+++ b/buildscripts/release.sh
@@ -3,4 +3,4 @@
 #------------------
 # CONTAINER VARIABLES
 #------------------
-export CONFLUENCE_VERSION=6.13.1
+export CONFLUENCE_VERSION=6.13.3


### PR DESCRIPTION
Update to Confluence 6.13.3 for a security bug

https://confluence.atlassian.com/doc/confluence-security-advisory-2019-03-20-966660264.html?_ga=2.10065533.91945946.1552823225-2017764017.1474150512